### PR TITLE
Save optimization output to .csv file 

### DIFF
--- a/asreviewcontrib/hyperopt/show_trials.py
+++ b/asreviewcontrib/hyperopt/show_trials.py
@@ -18,6 +18,10 @@ import pickle
 import pandas as pd
 import numpy as np
 
+import sys
+import os
+
+
 from asreview.entry_points.base import BaseEntryPoint
 
 
@@ -65,4 +69,13 @@ class ShowTrialsEntryPoint(BaseEntryPoint):
         values = load_trials(trials_fp)["values"]
         pd.options.display.max_rows = 999
         pd.options.display.width = 0
-        print(pd.DataFrame(values).sort_values("loss"))
+
+
+        trials_df = pd.DataFrame(values).sort_values("loss")
+
+        # store the trials as a csv file
+        if len(sys.argv) > 3:
+            filepath = os.path.join(sys.argv[3], 'trials.csv')
+            trials_df.to_csv(filepath, index = True, header = True, index_label = "trial")
+
+        print(trials_df)


### PR DESCRIPTION
Add the option to save optimization output to a .csv file. 

`asreview show trials.pkl` prints the optimization output from the trials.pkl file to the screen. 

This output can now be saved as a .csv file to a specified location by providing an extra argument, `asreview show trials.pkl .` or `asreview show trials.pkl optimization_output` for example.

@qubixes could you have a look?